### PR TITLE
Update cli.md

### DIFF
--- a/deploy/astrbot/cli.md
+++ b/deploy/astrbot/cli.md
@@ -11,7 +11,7 @@
 如果你的电脑上安装了 `git`，你可以通过以下命令来下载源码：
 
 ```bash
-git clone http://github.com/Soulter/AstrBot
+git clone https://github.com/AstrBotDevs/AstrBot.git
 cd AstrBot
 ```
 


### PR DESCRIPTION
修正了文档中的github仓库链接

## Sourcery 总结

文档：
- 更新 cli.md 中的 `git clone` URL，使其指向正确的 AstrBotDevs/AstrBot 仓库（通过 HTTPS）

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the `git clone` URL in cli.md to point to the correct AstrBotDevs/AstrBot repository over HTTPS

</details>